### PR TITLE
ensure the exit status reflects test results... 0 for pass

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -457,7 +457,7 @@ console output.
                     }
 
                     if (msgs[1] === 'done') {
-                        result = message.data;
+                        result = message.details;
                         failed = !result || result.failed;
 
                         phantom.exit(failed ? errorcode : 0);


### PR DESCRIPTION
Phantom should exit reflecting the failure status of the tests carried out. message.data seems to be a typo for message.details in this instance and in my tests.
Either this or message.data should contain the result of cb(message.details)?
